### PR TITLE
Update MainActivity.kt

### DIFF
--- a/app/src/main/java/com/example/socialapp/MainActivity.kt
+++ b/app/src/main/java/com/example/socialapp/MainActivity.kt
@@ -46,6 +46,7 @@ class MainActivity : AppCompatActivity(), IPostAdapter {
 
     override fun onStop() {
         super.onStop()
+        adapter.notifyDataSetChange()
         adapter.stopListening()
     }
 


### PR DESCRIPTION
Please look into this as a lot of my friends facing the same issue. For the first time we set the adapter for Recycler View but every time MainActivity we also have to inform the adapter about the change in the data therefore, calling notifyDataSetChanged() is crucial to avoid crashing the app.